### PR TITLE
add peer dependencies of dependent packages to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "lodash": "^3.10.0",
     "mime": "^1.2.11",
     "body-parser": "~1.13.3",
-    "run-sequence": "~1.1.2"
+    "run-sequence": "~1.1.2",
+    "phantomjs": "*",
+    "jasmine-core": "*"
   },
   "dependencies": {
 


### PR DESCRIPTION
Starting from npm@3 peer dependencies are not installed by default.
I believe it's assumed, that if package A depends on package B that
have peer dependency C, A must install C in order to use B.

Discussion of that npm change can be found here: https://github.com/npm/npm/issues/5080

Not sure either `"*"` version of peer dependency should be specified in parent package or specific version.
I think `"*"` version will lead npm to use best matching version that satisfies dependent package.

To reproduce issue that this PR is fixing you can upgrade npm to version newer than 3.0 and try to do clean installation of `buildbot/www/*` packages (with removed `node_modules`).