### PR TITLE
Add `is_library` config variable that skips minification and babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ You can see it in action at https://github.com/buildbot/buildbot/tree/master/www
 
 ### ChangeLog
 
+* 1.1.0: Add support to skip babel transpilation and minification for libraries.
 * 1.0.0: This package is not maintained for anything outside the Buildbot project.
          Added support for transcoding Javascript via babel.
 * 0.9.2: Upgrade dependencies. Add builtin support for JavaScript sources in addition to CoffeeScript.

--- a/defaultconfig.coffee
+++ b/defaultconfig.coffee
@@ -101,6 +101,11 @@ module.exports =
                 "modules": false
             ]
         ]
+
+    # Enable library mode. For reusable libraries we don't want to do babel transpilation and
+    # minification as this will be done by the downstream user. Babel can't ingest its own output.
+    is_library: false
+
     # Enable code coverage on coffeescript. ATM, this restricts you to CS 1.6,
     # so you might want to disable it.
     coffee_coverage: true

--- a/main.coffee
+++ b/main.coffee
@@ -169,7 +169,7 @@ module.exports =  (gulp) ->
             .pipe gif(dev or config.sourcemaps, sourcemaps.init())
             .pipe cached('scripts')
             # babel build
-            .pipe(catch_errors(gif("*.js", babel(config.babel))))
+            .pipe(catch_errors(gif(not config.is_library, gif("*.js", babel(config.babel)))))
             # coffee build
             .pipe(catch_errors(gif("*.coffee", coffeeCompile().pipe(gif(prod, annotate())))))
             # jade build
@@ -180,7 +180,7 @@ module.exports =  (gulp) ->
             .pipe(catch_errors(gif("*.jjs", jadeConcat())))
             .pipe concat(config.output_scripts)
             # now everything is in js, do minification
-            .pipe gif(prod, uglify())
+            .pipe gif(prod and not config.is_library, uglify())
             .pipe gif(dev or config.sourcemaps, sourcemaps.write("."))
             .pipe gulp.dest config.dir.build
             .pipe gif(dev, lr())
@@ -191,10 +191,10 @@ module.exports =  (gulp) ->
             return
         gulp.src bower.deps
             .pipe gif(dev or config.sourcemaps, sourcemaps.init())
-            .pipe(catch_errors(gif("*.js", babel(config.babel))))
+            .pipe(catch_errors(gif(not config.is_library, gif("*.js", babel(config.babel)))))
             .pipe concat("vendors.js")
-            # now everything is in js, do angular annotation, and minification
-            .pipe gif(prod, uglify())
+            # now everything is in js, do minification
+            .pipe gif(prod and not config.is_library, uglify())
             .pipe gif(dev or config.sourcemaps, sourcemaps.write("."))
             .pipe gulp.dest config.dir.build
             .pipe gif(dev, lr())


### PR DESCRIPTION
The Javascript standard that the code is transpiled to should be responsibility of the downstream user. In addition to that, babel does not support being fed code that was already transpiled by it. To solve this, an option to disable transpiling and minification has been added.